### PR TITLE
Add black step to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,11 @@ repos:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
 
+  - repo: https://github.com/ambv/black
+    rev: 21.6b0
+    hooks:
+    - id: black
+
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.5.1
     hooks:


### PR DESCRIPTION
Resolves #4 

It is unclear to me if the new pre-commit GH action step plays well with black. The correct way to lint for black in CI is `black --check .`