### PR TITLE
Change menu keybind

### DIFF
--- a/text_editor.py
+++ b/text_editor.py
@@ -228,8 +228,14 @@ bindings = KeyBindings()
 
 @bindings.add("c-c")
 def _(event: object) -> None:
-    """Focus menu. No idea what the type annotation of this even is"""
+    """Focus menu."""
     event.app.layout.focus(root_container.window)
+
+
+@bindings.add("escape")
+def _(event: object) -> None:
+    """Focus text field."""
+    event.app.layout.focus(text_field)
 
 
 #

--- a/text_editor.py
+++ b/text_editor.py
@@ -51,7 +51,7 @@ class ApplicationState:
 # TODO make something like this that will pull up the side file menu
 def get_statusbar_text() -> None:
     """Gets status bar opens menu"""
-    return " Press Ctrl-C to open menu. "
+    return " Press Ctrl-H to open menu. "
 
 
 def get_statusbar_right_text() -> None:
@@ -226,7 +226,7 @@ body = HSplit(
 bindings = KeyBindings()
 
 
-@bindings.add("c-c")
+@bindings.add("c-h")
 def _(event: object) -> None:
     """Focus menu."""
     event.app.layout.focus(root_container.window)


### PR DESCRIPTION
Resolves https://github.com/CupOfGeo/adaptable-antelopes/issues/11

This pull request introduces two changes:
1. Change the menu keybind from CTRL+C (conflicts with copy on windows) to CTRL+H.
2. Introduce a new keybind to focus the text field. This allows a user to exit the menu without making a selection.