### PR TITLE
Display file's contents up to 1000th character.

### DIFF
--- a/src/scroll/scroll_menu.py
+++ b/src/scroll/scroll_menu.py
@@ -102,7 +102,8 @@ class ScrollMenuDialog(PopUpDialog):
         if isfile(join(target_dir, target_content)):
             # open file's content
             with open(join(target_dir, target_content), "r") as f:
-                file_content = f.read()
+                # Read up to 1000th character.
+                file_content = f.read(1000)
             self.cur_file_path = join(target_dir, target_content)
 
             # Remove any object that isn't HSplit


### PR DESCRIPTION
Displaying a huge file can slow the program. Scroll menu should only peaks through a small portion of it.