### PR TITLE
Handle edge case where user enters an invalid path

### DIFF
--- a/src/text/text_editor.py
+++ b/src/text/text_editor.py
@@ -299,14 +299,27 @@ def do_save_as_file() -> None:
     """Try to Save As a file under a new name/path."""
 
     async def coroutine() -> None:
+        """
+        Prompt the user for a file path to save their note.
+
+        If the path entered is a valid file name, save the current note at that path.
+        """
         open_dialog = TextInputDialog(
             title="Save As", label_text="Enter the path of the file:"
         )
-
-        path = NOTES_DIR + "/" + await show_dialog_as_float(open_dialog)
-        set_current_path(path)
-        if get_current_path() is not None:
-            save_file_at_path(get_current_path(), text_field.text)
+        user_entered_path = await show_dialog_as_float(open_dialog)
+        # Validate that the user entered path is not an empty string and doesn't consist exclusively of whitespace.
+        if (
+            user_entered_path
+            and not str.isspace(user_entered_path)
+            and user_entered_path not in [".", ".."]
+        ):
+            path = NOTES_DIR + "/" + user_entered_path
+            set_current_path(path)
+            save_file_at_path(path, text_field.text)
+        else:
+            # Fail silently
+            pass
 
     ensure_future(coroutine())
 

--- a/src/text/text_editor.py
+++ b/src/text/text_editor.py
@@ -308,7 +308,10 @@ def do_save_as_file() -> None:
             title="Save As", label_text="Enter the path of the file:"
         )
         user_entered_path = await show_dialog_as_float(open_dialog)
-        # Validate that the user entered path is not an empty string and doesn't consist exclusively of whitespace.
+        # Validate that the user entered path is
+        # 1. Not an empty string or None
+        # 2. Doesn't consist exclusively of whitespace
+        # 3. Isn't the string "." or ".."
         if (
             user_entered_path
             and not str.isspace(user_entered_path)


### PR DESCRIPTION
This pull request fixes the save case where a user enters an invalid file path to save their file.

If a user enters an invalid path, it will not save silently. This is a bug, I am not sure how to resolve it.