### PR TITLE
Add the ability to create, rename, and delete folders

### DIFF
--- a/src/application/state.py
+++ b/src/application/state.py
@@ -15,9 +15,8 @@ class ApplicationState:
             # if for some reason the file is deleted but then i need to maintain all the setting here
             # no style dict atm for users prefs not used anywhere yet
             self.user_settings = {"last_path": None, "style": ""}  # color picker?
-            with open(os.path.join(NOTES_DIR, ".user_setting.json"), "w") as j:
-                default_user_settings = json.dumps(self.user_settings)
-                j.write(default_user_settings)
+            with open(os.path.join(NOTES_DIR, ".user_setting.json"), "w") as f:
+                json.dump(self.user_settings, f)
 
         self.show_status_bar = True
         if self.user_settings.get("last_path"):
@@ -25,3 +24,14 @@ class ApplicationState:
         else:
             # Open the welcome page
             self.current_path = NOTES_DIR + "/" + WELCOME_PAGE
+
+    @property
+    def current_dir(self) -> str:
+        """
+        Returns the directory of the current path.
+
+        If there is no current path, return NOTES_DIR
+        """
+        if self.current_path:
+            return os.path.dirname(self.current_path)
+        return NOTES_DIR

--- a/src/custom_types/confirm.py
+++ b/src/custom_types/confirm.py
@@ -21,8 +21,8 @@ class ConfirmDialog(PopUpDialog):
             """Cancel the dialog."""
             self.future.set_result(False)
 
-        yes_button = Button(text="Yes", handler=(lambda: set_done()))
-        no_button = Button(text="No", handler=(lambda: set_cancel()))
+        yes_button = Button(text="Yes", handler=set_done)
+        no_button = Button(text="No", handler=set_cancel)
 
         self.dialog = Dialog(
             title=title,

--- a/src/custom_types/confirm.py
+++ b/src/custom_types/confirm.py
@@ -28,7 +28,7 @@ class ConfirmDialog(PopUpDialog):
             title=title,
             body=HSplit([Label(text=text)]),
             buttons=[yes_button, no_button],
-            width=D(preferred=80),
+            width=D(preferred=100),
             modal=True,
         )
 

--- a/src/custom_types/message.py
+++ b/src/custom_types/message.py
@@ -18,7 +18,7 @@ class MessageDialog(PopUpDialog):
             """Close this dialog by returning None to indicate the caller that it's done."""
             self.future.set_result(None)
 
-        ok_button = Button(text="OK", handler=(lambda: set_done()))
+        ok_button = Button(text="OK", handler=set_done)
 
         self.dialog = Dialog(
             title=title,

--- a/src/navigation/menu_bar.py
+++ b/src/navigation/menu_bar.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import os
 from asyncio import ensure_future
+from typing import Optional, Union
 
 from emoji import emojize
 from prompt_toolkit.application.current import get_app
@@ -41,10 +42,14 @@ class MenuNav:
                 MenuItem(
                     "File",
                     children=[
-                        MenuItem("New...", handler=self.do_new_file),
+                        MenuItem("New Note...", handler=self.do_new_file),
                         MenuItem("Open", handler=self.do_scroll_menu),
                         MenuItem("Save", handler=self.do_save_file),
                         MenuItem("Save as...", handler=self.do_save_as_file),
+                        MenuItem("-", disabled=True),
+                        MenuItem("New Folder", handler=self.do_new_folder),
+                        MenuItem("Rename Folder", handler=self.do_rename_folder),
+                        MenuItem("Delete Folder", handler=self.do_delete_folder),
                         MenuItem("-", disabled=True),
                         MenuItem("Exit", handler=self.do_exit),
                     ],
@@ -126,6 +131,9 @@ class MenuNav:
                 title="Save As", label_text="Enter the path of the file:"
             )
             user_entered_path = await self.show_dialog_as_float(open_dialog)
+            if user_entered_path is None:
+                return
+
             dir_name, file_name = os.path.split(user_entered_path)
             # Validate that the user entered path:
             # 1. Is not the empty string or None
@@ -137,7 +145,9 @@ class MenuNav:
                 and not user_entered_path.isspace()
                 and not user_entered_path.startswith(".")
                 and not file_name.startswith(".")
-                and (dir_name == "" or os.path.exists(dir_name))
+                and (
+                    dir_name == "" or os.path.exists(os.path.join(NOTES_DIR, dir_name))
+                )
             ):
                 if not (
                     user_entered_path.endswith(".txt")
@@ -158,14 +168,37 @@ class MenuNav:
                 path = os.path.join(NOTES_DIR, user_entered_path)
                 self._save_file_at_path(path, self.text_field.text)
             else:
-                if user_entered_path is not None:
-                    self.show_message("Invalid Path", "Please enter a valid file name.")
+                self.show_message("Invalid Path", "Please enter a valid file name.")
 
         ensure_future(coroutine())
 
     def do_scroll_menu(self) -> None:
         """Open Scroll Menu"""
-        self._show_scroll("Open Note")
+
+        async def coroutine(self: MenuNav) -> None:
+            dialog = ScrollMenuDialog(
+                title="Open Note",
+                text="File content here",
+                directory=self.application_state.current_dir,
+                show_files=True,
+            )
+            path = await self.show_dialog_as_float(dialog)
+            # Only add to text_editor if the given file is text file or markdown file.
+            if path:
+                if os.path.splitext(path)[1] in (".txt", ".md"):
+                    self.application_state.current_path = path
+                    with open(path, "r") as f:
+                        self.text_field.text = f.read()
+
+                    set_title(f"ThoughtBox - {path}")
+                else:
+                    # Else show a popup message revealing the error message
+                    self.show_message(
+                        title="extension_error",
+                        text="Unsupported file extension. Only '.txt' and '.md' are supported",
+                    )
+
+        ensure_future(coroutine(self))
 
     def do_about(self) -> None:
         """About from menu select"""
@@ -176,6 +209,44 @@ class MenuNav:
         self.text_field.text = ""
         self.application_state.current_path = None
         set_title("ThoughtBox - Untitled")
+
+    def do_new_folder(self) -> None:
+        """Creates a folder"""
+
+        async def coroutine(self: MenuNav) -> None:
+            dialog = ScrollMenuDialog(
+                title="New Folder",
+                text="Choose the location of the new folder.",
+                directory=self.application_state.current_dir,
+                show_files=False,
+            )
+            path = await self.show_dialog_as_float(dialog)
+            if path:
+                dialog = TextInputDialog(
+                    "New Folder", label_text="Enter the name of the folder:"
+                )
+                name = await self.show_dialog_as_float(dialog)
+                if name:
+                    try:
+                        os.makedirs(os.path.join(path, name))
+                    except OSError:
+                        self.show_message(
+                            title="New Folder",
+                            text="That folder already exists or has an invalid name.",
+                        )
+                    else:
+                        self.show_message(
+                            title="New Folder",
+                            text=f"Folder at {os.path.join(path, name)} was created.",
+                        )
+
+        ensure_future(coroutine(self))
+
+    def do_rename_folder(self) -> None:
+        """Renames a folder"""
+
+    def do_delete_folder(self) -> None:
+        """Delete a folder"""
 
     def do_exit(self) -> None:
         """Exit"""
@@ -271,15 +342,6 @@ class MenuNav:
             set_title(f"ThoughtBox - {path}")
             self.application_state.current_path = path
 
-    def _show_scroll(self, title: str) -> None:
-        """Shows a ScrollMenu with a certain title"""
-
-        async def coroutine(self: MenuNav) -> None:
-            dialog = ScrollMenuDialog(self, title)
-            await self.show_dialog_as_float(dialog)
-
-        ensure_future(coroutine(self))
-
     def show_message(self, title: str, text: str, centered: bool = True) -> None:
         """Shows about message"""
         if centered:
@@ -292,8 +354,10 @@ class MenuNav:
 
         ensure_future(coroutine(self))
 
-    async def show_dialog_as_float(self, dialog: PopUpDialog) -> None:
-        """Coroutine what does it return idk? the messageDialogs future result which is None?"""
+    async def show_dialog_as_float(
+        self, dialog: PopUpDialog
+    ) -> Optional[Union[str, bool]]:
+        """Focuses a dialog. Returns the dialog's future. Then refocuses the original window."""
         float_ = Float(content=dialog)
         # Put given dialog on top of everything
         self.root_container.floats.insert(0, float_)
@@ -304,7 +368,7 @@ class MenuNav:
         focused_before = app.layout.current_window
         # Focus cursor to the given dialog
         app.layout.focus(dialog)
-        # Wait for the dialog to finish (returns None)
+        # Wait for the dialog to finish and stores the future's result
         result = await dialog.future
         # Re-focus cursor back to window in temp variable
         app.layout.focus(focused_before)

--- a/src/navigation/menu_bar.py
+++ b/src/navigation/menu_bar.py
@@ -221,24 +221,47 @@ class MenuNav:
                 show_files=False,
             )
             path = await self.show_dialog_as_float(dialog)
-            if path:
-                dialog = TextInputDialog(
-                    "New Folder", label_text="Enter the name of the folder:"
+            if not path:
+                return
+
+            dialog = TextInputDialog(
+                "New Folder", label_text="Enter the name of the folder:"
+            )
+            folder_name = await self.show_dialog_as_float(dialog)
+            if folder_name is None:
+                return
+
+            # Validate that the folder name:
+            # 1. Is not the empty string or None
+            # 2. Doesn't consist exclusively of whitespace
+            # 3. Doesn't start with "."
+            if (
+                folder_name
+                and not folder_name.isspace()
+                and not folder_name.startswith(".")
+            ):
+                if os.path.exists(os.path.join(path, folder_name)):
+                    return self.show_message(
+                        title="New Folder", text="That folder already exists."
+                    )
+
+                try:
+                    os.mkdir(os.path.join(path, folder_name))
+                except OSError:
+                    self.show_message(
+                        title="New Folder",
+                        text="Please enter a valid folder name.",
+                    )
+                else:
+                    self.show_message(
+                        title="New Folder",
+                        text=f"Folder at {os.path.join(path, folder_name)} was created.",
+                    )
+            else:
+                self.show_message(
+                    title="New Folder",
+                    text="Please enter a valid folder name.",
                 )
-                name = await self.show_dialog_as_float(dialog)
-                if name:
-                    try:
-                        os.makedirs(os.path.join(path, name))
-                    except OSError:
-                        self.show_message(
-                            title="New Folder",
-                            text="That folder already exists or has an invalid name.",
-                        )
-                    else:
-                        self.show_message(
-                            title="New Folder",
-                            text=f"Folder at {os.path.join(path, name)} was created.",
-                        )
 
         ensure_future(coroutine(self))
 

--- a/src/navigation/menu_bar.py
+++ b/src/navigation/menu_bar.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import os
 from asyncio import ensure_future
+from shutil import rmtree
 from typing import Optional, Union
 
 from emoji import emojize
@@ -265,7 +266,7 @@ class MenuNav:
             if path == NOTES_DIR:
                 return self.show_message(
                     title="Rename Folder",
-                    text="You cannot choose the root folder.",
+                    text="You cannot rename the root folder.",
                 )
 
             dialog = TextInputDialog(
@@ -312,6 +313,45 @@ class MenuNav:
 
     def do_delete_folder(self) -> None:
         """Delete a folder"""
+
+        async def coroutine(self: MenuNav) -> None:
+            dialog = ScrollMenuDialog(
+                title="Delete Folder",
+                text="Choose the folder you want to delete.",
+                directory=self.application_state.current_dir,
+                show_files=False,
+            )
+            path = await self.show_dialog_as_float(dialog)
+            if not path:
+                return
+
+            if path == NOTES_DIR:
+                return self.show_message(
+                    title="Delete Folder",
+                    text="You cannot delete the root folder.",
+                )
+
+            dialog = ConfirmDialog(
+                title="Delete Folder",
+                text=f"Are you sure you want to delete {path} and all of its contents?",
+            )
+            confirm_delete = await self.show_dialog_as_float(dialog)
+
+            if confirm_delete:
+                try:
+                    rmtree(path)
+                except OSError:
+                    self.show_message(
+                        title="Delete Folder",
+                        text="Failed to delete the folder.",
+                    )
+                else:
+                    self.show_message(
+                        title="Delete Folder",
+                        text=f"{path} was successfully deleted.",
+                    )
+
+        ensure_future(coroutine(self))
 
     def do_exit(self) -> None:
         """Exit"""


### PR DESCRIPTION
Addresses (#66)

- Also opens the scroll menu at the directory of the currently opened file (and in `NOTES_DIR` for new files)
- refactors `ScrollMenuDialog` to be able to show only folders with `show_files=False`
- adds a `current_dir` property that returns the directory of the current path, and `NOTES_DIR` for new files
