### PR TITLE
Add many functionalities for folders and notes

### DIFF
--- a/src/custom_types/scroll_menu.py
+++ b/src/custom_types/scroll_menu.py
@@ -2,7 +2,7 @@ import functools
 from asyncio import Future
 from os import listdir
 from os.path import basename, dirname, isdir, isfile, join, realpath
-from typing import List
+from typing import List, Optional
 
 from prompt_toolkit.application.current import get_app
 from prompt_toolkit.layout import FormattedTextControl, ScrollablePane, Window
@@ -18,7 +18,12 @@ class ScrollMenuDialog(PopUpDialog):
     """Scroll menu added to the info tab dialog box"""
 
     def __init__(
-        self, title: str, text: str, directory: str = NOTES_DIR, show_files: bool = True
+        self,
+        title: str,
+        text: str,
+        directory: str = NOTES_DIR,
+        show_files: bool = True,
+        path: Optional[str] = None,
     ):
         """Initialize Scroll Menu Dialog
 
@@ -27,9 +32,16 @@ class ScrollMenuDialog(PopUpDialog):
             text (str): Body of dialog
             directory (str): Default directory to open
             show_files (bool): Whether or not to show files in the scroll menu
+            path (Optional[str]): Set the initial path.
+                If None, defaults to None if show_files is True, otherwise defaults to directory.
         """
         self.future = Future()
-        self.path = None if show_files else directory
+        if path:
+            self.path = path
+        elif show_files:
+            self.path = None
+        else:
+            self.path = directory
 
         user_displayed_directory = "Explorer" if directory == NOTES_DIR else directory
 

--- a/src/navigation/menu_bar.py
+++ b/src/navigation/menu_bar.py
@@ -242,10 +242,10 @@ class MenuNav:
                     text="Unable to move item to that location.",
                 )
             else:
-                if self.application_state.current_path.startswith(item_path):
-                    set_title(
-                        f"ThoughtBox - {self.application_state.current_path} (Moved)"
-                    )
+                if (
+                    current_path := self.application_state.current_path
+                ) and current_path.startswith(item_path):
+                    set_title(f"ThoughtBox - {current_path} (Moved)")
                     self.application_state.current_path = None
                 self.show_message(
                     title="Move Item",
@@ -374,10 +374,10 @@ class MenuNav:
                         text="Please enter a valid name.",
                     )
                 else:
-                    if self.application_state.current_path.startswith(path):
-                        set_title(
-                            f"ThoughtBox - {self.application_state.current_path} (Moved)"
-                        )
+                    if (
+                        current_path := self.application_state.current_path
+                    ) and current_path.startswith(path):
+                        set_title(f"ThoughtBox - {current_path} (Moved)")
                         self.application_state.current_path = None
                     self.show_message(
                         title="Rename Item",
@@ -441,10 +441,10 @@ class MenuNav:
                         text="Failed to delete the folder.",
                     )
                 else:
-                    if self.application_state.current_path.startswith(path):
-                        set_title(
-                            f"ThoughtBox - {self.application_state.current_path} (Deleted)"
-                        )
+                    if (
+                        current_path := self.application_state.current_path
+                    ) and current_path.startswith(path):
+                        set_title(f"ThoughtBox - {current_path} (Deleted)")
                         self.application_state.current_path = None
                     self.show_message(
                         title="Delete Folder",

--- a/src/navigation/menu_bar.py
+++ b/src/navigation/menu_bar.py
@@ -98,7 +98,7 @@ class MenuNav:
             key_bindings=self._setup_keybindings(),
         )
 
-    ############ MENU ITEMS #############
+    ############ HANDLERS FOR MENU ITEMS #############
     def do_save_file(self) -> None:
         """Try to save. If no file is being edited, save as instead to create a new one."""
         if path := self.application_state.current_path:

--- a/src/navigation/menu_bar.py
+++ b/src/navigation/menu_bar.py
@@ -551,9 +551,6 @@ class MenuNav:
             set_title(f"ThoughtBox - {path}")
             self.application_state.current_path = path
 
-    def validate_path(self, path: str) -> bool:
-        """Validates if the path can be created."""
-
     def show_message(self, title: str, text: str, centered: bool = True) -> None:
         """Shows About message"""
         # Align text content center

--- a/src/navigation/menu_bar.py
+++ b/src/navigation/menu_bar.py
@@ -258,18 +258,25 @@ class MenuNav:
         """Creates a folder"""
 
         async def coroutine(self: MenuNav) -> None:
-            dialog = ScrollMenuDialog(
-                title="New Folder",
-                text="Choose the location of the new folder.",
-                directory=self.application_state.current_dir,
-                show_files=False,
+            has_folders = any(
+                os.path.isdir(os.path.join(NOTES_DIR, f)) for f in os.listdir(NOTES_DIR)
             )
-            path = await self.show_dialog_as_float(dialog)
-            if not path:
-                return
+            if has_folders:
+                dialog = ScrollMenuDialog(
+                    title="New Folder",
+                    text="Choose the location of the new folder.",
+                    directory=self.application_state.current_dir,
+                    show_files=False,
+                )
+                path = await self.show_dialog_as_float(dialog)
+                if not path:
+                    return
+            else:
+                # Skip the scroll menu if there are no folders yet (to not confuse users)
+                path = NOTES_DIR
 
             dialog = TextInputDialog(
-                "New Folder", label_text="Enter the name of the folder:"
+                "New Folder", label_text="Enter the name of the new folder:"
             )
             folder_name = await self.show_dialog_as_float(dialog)
             if folder_name is None:

--- a/src/navigation/menu_bar.py
+++ b/src/navigation/menu_bar.py
@@ -212,6 +212,12 @@ class MenuNav:
             if not item_path:
                 return
 
+            if item_path == NOTES_DIR:
+                return self.show_message(
+                    title="Move Item",
+                    text="You cannot move the root folder.",
+                )
+
             dialog = ScrollMenuDialog(
                 title="Move Item",
                 text="Choose the location where you want to move the item to.",
@@ -219,6 +225,15 @@ class MenuNav:
                 show_files=False,
             )
             move_path = await self.show_dialog_as_float(dialog)
+            if not move_path:
+                return
+
+            if os.path.exists(os.path.join(move_path, os.path.basename(item_path))):
+                return self.show_message(
+                    title="Move Item",
+                    text=f"{os.path.basename(item_path)} already exists at that location.",
+                )
+
             try:
                 shutil.move(item_path, move_path)
             except OSError:


### PR DESCRIPTION
### Notes
- Rename 
- Move
- Delete
### Folders
- Move

Also fixes the bug when the folder that the currently opened note is in or the currently opened note is renamed, moved, or deleted, and then you save it. It now will prompt a Save As since the note no longer "exists" (it may exist if it was moved or renamed, just not at the old path).