### PR TITLE
Move prompt_toolkit to requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,8 +5,6 @@ filelock==3.0.12
 identify==2.2.11
 nodeenv==1.6.0
 pre-commit==2.13.0
-prompt-toolkit==3.0.19
-Pygments==2.9.0
 PyYAML==5.4.1
 pytest==6.2.4
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 # Application
+prompt-toolkit==3.0.19
 emoji==1.2.0
+Pygments==2.9.0


### PR DESCRIPTION
It's a 3rd-party dependency so we want the user to install that.